### PR TITLE
Updated Feature to allow 'null' properties member as defined by RFC 7946

### DIFF
--- a/src/schema/Feature.js
+++ b/src/schema/Feature.js
@@ -17,7 +17,7 @@ module.exports = {
       emum: ['Feature']
     },
     properties: {
-      type: 'object'
+      oneOf: [{type: 'null'}, {type: 'object'}]
     },
     geometry: {
       oneOf: [


### PR DESCRIPTION
While attempting to use JSON schema to validate some RFC 7946 compliant JSON, I noticed that the schema prohibited `properties` member of `Feature` type from being set to `null`. From my reading of the RFC this seems to be overly restrictive.