### PR TITLE
Downgrade event-stream to 3.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -987,13 +987,12 @@
       "dev": true
     },
     "event-stream": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.5.tgz",
+      "integrity": "sha512-vyibDcu5JL20Me1fP734QBH/kenBGLZap2n0+XXM7mvuUPzJ20Ydqj1aKcIeMdri1p+PU+4yAKugjN8KCVst+g==",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
-        "flatmap-stream": "^0.1.0",
         "from": "^0.1.7",
         "map-stream": "0.0.7",
         "pause-stream": "^0.0.11",
@@ -1286,12 +1285,6 @@
         "graceful-fs": "^4.1.2",
         "write": "^0.2.1"
       }
-    },
-    "flatmap-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-      "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
-      "dev": true
     },
     "for-in": {
       "version": "1.0.2",


### PR DESCRIPTION
https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident

Apparently, `event-stream@3.3.6` was compromised and was removed from npm.
package-lock.json is locked to this version, so I removed event-stream from
package-lock.json and regenerated the file. `make` now runs without error.