### PR TITLE
Additional fixtures

### DIFF
--- a/test/fixtures/invalid/feature/1d-point.json
+++ b/test/fixtures/invalid/feature/1d-point.json
@@ -1,0 +1,13 @@
+{
+  "id": "ABC",
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      -122.308150179
+    ]
+  },
+  "properties": {
+    "name": "Dinagat Islands"
+  }
+}

--- a/test/fixtures/valid/feature/empty-polygon.json
+++ b/test/fixtures/valid/feature/empty-polygon.json
@@ -1,0 +1,9 @@
+{
+  "id": "ABC",
+  "type": "Feature",
+  "properties": {},
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": []
+  }
+}


### PR DESCRIPTION
This adds fixtures to the tests to ensure that polygons with empty coordinates are considered valid and point coordinates with one value are invalid.

Fixes #11.